### PR TITLE
ImGui Dockspace

### DIFF
--- a/KaguEngine/src/App.cpp
+++ b/KaguEngine/src/App.cpp
@@ -97,25 +97,21 @@ void App::run() {
             if(uboBuffers[frameIndex]->flush() != VK_SUCCESS)
                 throw std::runtime_error("Couldn't flush the ubo for one frame!");
 
-            // render
-            m_Renderer.beginSwapChainRenderPass(commandBuffer);
-            if (m_Renderer.isSwapChainRecreated()) {
-                imGuiContext.recreateSwapChain();
-                m_Renderer.setSwapChainRecreated();
-            }
-
-            // order here matters
+            // Offscreen rendering
+            m_Renderer.beginOffscreenRenderPass(commandBuffer);
             renderSystem.renderGameObjects(frameInfo);
             pointLightSystem.render(frameInfo);
+            m_Renderer.endOffscreenRenderPass(commandBuffer);
 
-            // ImGui
-            imGuiContext.render(commandBuffer);
+            // ImGui rendering
+            m_Renderer.transitionOffscreenImageForImGui();
+            imGuiContext.render(m_Renderer);
 
+            // Present the image
+            m_Renderer.beginSwapChainRenderPass(commandBuffer);
+            imGuiContext.onPresent(commandBuffer);
             m_Renderer.endSwapChainRenderPass(commandBuffer);
-            if (m_Renderer.isSwapChainRecreated()) {
-                imGuiContext.recreateSwapChain();
-                m_Renderer.setSwapChainRecreated();
-            }
+
             m_Renderer.endFrame();
         }
     }

--- a/KaguEngine/src/ImGuiContext.cpp
+++ b/KaguEngine/src/ImGuiContext.cpp
@@ -60,7 +60,7 @@ void ImGuiContext::setupContext() const {
     init_info.Allocator = nullptr;
     init_info.Subpass = 0;
     init_info.MinImageCount = SwapChain::MAX_FRAMES_IN_FLIGHT;
-    init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;//deviceRef.getSampleCount();
+    init_info.MSAASamples = deviceRef.getSampleCount();
     init_info.ImageCount = SwapChain::MAX_FRAMES_IN_FLIGHT;
     //init_info.CheckVkResultFn = check_vk_result;
     ImGui_ImplVulkan_Init(&init_info);

--- a/KaguEngine/src/ImGuiContext.ixx
+++ b/KaguEngine/src/ImGuiContext.ixx
@@ -10,6 +10,7 @@ import std;
 import KaguEngine.Descriptor;
 import KaguEngine.Device;
 import KaguEngine.SwapChain;
+import KaguEngine.Renderer;
 import KaguEngine.Window;
 
 export namespace KaguEngine {
@@ -21,14 +22,15 @@ public:
     ~ImGuiContext();
 
     void recreateSwapChain() const;
-    void render(VkCommandBuffer commandBuffer);
+    void render(Renderer& renderer);
+    void onPresent(VkCommandBuffer commandBuffer);
 
 private:
     void setupContext() const;
     void setupConfigFlags();
     void setupStyle();
     void beginRender();
-    void onRender();
+    void onRender(Renderer& renderer);
     void endRender();
 
     std::unique_ptr<DescriptorPool> &poolRef;

--- a/KaguEngine/src/Pipeline.cpp
+++ b/KaguEngine/src/Pipeline.cpp
@@ -209,7 +209,7 @@ void Pipeline::enableAlphaBlending(PipelineConfigInfo &configInfo) {
 }
 
 void Pipeline::enableMSAA(PipelineConfigInfo &configInfo, const VkSampleCountFlagBits &msaaLevel) {
-    configInfo.multisampleInfo.rasterizationSamples = msaaLevel;
+    configInfo.multisampleInfo.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;//msaaLevel;
 }
 
 } // Namespace KaguEngine

--- a/KaguEngine/src/Pipeline.cpp
+++ b/KaguEngine/src/Pipeline.cpp
@@ -203,13 +203,13 @@ void Pipeline::enableAlphaBlending(PipelineConfigInfo &configInfo) {
     configInfo.colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
     configInfo.colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     configInfo.colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
-    configInfo.colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-    configInfo.colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    configInfo.colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    configInfo.colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     configInfo.colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
 }
 
 void Pipeline::enableMSAA(PipelineConfigInfo &configInfo, const VkSampleCountFlagBits &msaaLevel) {
-    configInfo.multisampleInfo.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;//msaaLevel;
+    configInfo.multisampleInfo.rasterizationSamples = msaaLevel;
 }
 
 } // Namespace KaguEngine

--- a/KaguEngine/src/Renderer.cpp
+++ b/KaguEngine/src/Renderer.cpp
@@ -20,20 +20,23 @@ namespace KaguEngine {
 
 Renderer::Renderer(Window &window, Device &device) : windowRef{window}, deviceRef{device} {
     recreateSwapChain();
+    createOffscreenResources();
     createCommandBuffers();
 }
 
-Renderer::~Renderer() { freeCommandBuffers(); }
+Renderer::~Renderer() {
+    freeCommandBuffers();
+    cleanupOffscreenResources();
+}
 
 void Renderer::recreateSwapChain() {
-    m_isSwapChainRecreated = true;
     auto extent = windowRef.getExtent();
     while (extent.width == 0 || extent.height == 0) {
         extent = windowRef.getExtent();
         glfwWaitEvents();
     }
     vkDeviceWaitIdle(deviceRef.device());
-
+    cleanupOffscreenResources();
     if (m_SwapChain == nullptr) {
         m_SwapChain = std::make_unique<SwapChain>(deviceRef, extent);
     } else {
@@ -43,6 +46,7 @@ void Renderer::recreateSwapChain() {
             throw std::runtime_error("Swap chain image(or depth) format has changed!");
         }
     }
+    createOffscreenResources();
 }
 
 void Renderer::createCommandBuffers() {
@@ -147,6 +151,396 @@ void Renderer::endSwapChainRenderPass(const VkCommandBuffer commandBuffer) const
     assert(commandBuffer == getCurrentCommandBuffer() &&
            "Can't end render pass on command buffer from a different frame");
     vkCmdEndRenderPass(commandBuffer);
+}
+
+void Renderer::createOffscreenResources() {
+    cleanupOffscreenResources();
+
+    m_offscreenExtent = windowRef.getExtent();
+    m_offscreenFormat = VK_FORMAT_B8G8R8A8_SRGB;
+
+    // Create color image + view
+    VkImageCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    createInfo.imageType = VK_IMAGE_TYPE_2D;
+    createInfo.extent.width = m_offscreenExtent.width;
+    createInfo.extent.height = m_offscreenExtent.height;
+    createInfo.extent.depth = 1;
+    createInfo.mipLevels = 1;
+    createInfo.arrayLayers = 1;
+    createInfo.format = m_offscreenFormat;
+    createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    createInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    createInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    createInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    createInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    createInfo.flags = 0;
+    deviceRef.createImageWithInfo(createInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, m_offscreenImage, m_offscreenImageMemory);
+    m_offscreenImageView = m_SwapChain->createImageView(m_offscreenImage, m_offscreenFormat, VK_IMAGE_ASPECT_COLOR_BIT, 1);
+
+    // Create sampler
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.anisotropyEnable = VK_FALSE;
+    samplerInfo.maxAnisotropy = 1.0f;
+    samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+    samplerInfo.unnormalizedCoordinates = VK_FALSE;
+    samplerInfo.compareEnable = VK_FALSE;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    if (vkCreateSampler(deviceRef.device(), &samplerInfo, nullptr, &m_offscreenSampler) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create offscreen sampler!");
+    }
+
+    // Create depth image
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.extent.width = m_offscreenExtent.width;
+    imageInfo.extent.height = m_offscreenExtent.height;
+    imageInfo.extent.depth = 1;
+    imageInfo.mipLevels = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.format = m_SwapChain->findDepthFormat();
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.flags = 0;
+
+    deviceRef.createImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, m_offscreenDepthImage, m_offscreenDepthMemory);
+
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = m_offscreenDepthImage;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = m_SwapChain->findDepthFormat();
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = 1;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(deviceRef.device(), &viewInfo, nullptr, &m_offscreenDepthView) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create texture image view!");
+    }
+
+    transitionImageLayout(m_offscreenImage, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    m_offscreenCurrentLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    createOffscreenRenderPass();
+    createOffscreenFramebuffer();
+    createOffscreenDescriptorSet();
+}
+
+void Renderer::cleanupOffscreenResources() {
+    auto device = deviceRef.device();
+
+    if (m_offscreenImGuiDescriptorSet) {
+        // ImGui will clean up its descriptor set, do not free here
+        m_offscreenImGuiDescriptorSet = VK_NULL_HANDLE;
+    }
+
+    if (m_offscreenDescriptorPool) {
+        vkDestroyDescriptorPool(device, m_offscreenDescriptorPool, nullptr);
+        m_offscreenDescriptorPool = VK_NULL_HANDLE;
+    }
+    if (m_offscreenDescriptorSetLayout) {
+        vkDestroyDescriptorSetLayout(device, m_offscreenDescriptorSetLayout, nullptr);
+        m_offscreenDescriptorSetLayout = VK_NULL_HANDLE;
+    }
+    if (m_offscreenFramebuffer) {
+        vkDestroyFramebuffer(device, m_offscreenFramebuffer, nullptr);
+        m_offscreenFramebuffer = VK_NULL_HANDLE;
+    }
+    if (m_offscreenRenderPass) {
+        vkDestroyRenderPass(device, m_offscreenRenderPass, nullptr);
+        m_offscreenRenderPass = VK_NULL_HANDLE;
+    }
+    if (m_offscreenImageView) {
+        vkDestroyImageView(device, m_offscreenImageView, nullptr);
+        m_offscreenImageView = VK_NULL_HANDLE;
+    }
+    if (m_offscreenImage) {
+        vkDestroyImage(device, m_offscreenImage, nullptr);
+        m_offscreenImage = VK_NULL_HANDLE;
+    }
+    if (m_offscreenImageMemory) {
+        vkFreeMemory(device, m_offscreenImageMemory, nullptr);
+        m_offscreenImageMemory = VK_NULL_HANDLE;
+    }
+    if (m_offscreenSampler) {
+        vkDestroySampler(device, m_offscreenSampler, nullptr);
+        m_offscreenSampler = VK_NULL_HANDLE;
+    }
+    if (m_offscreenDepthView) {
+        vkDestroyImageView(device, m_offscreenDepthView, nullptr);
+        m_offscreenDepthView = VK_NULL_HANDLE;
+    }
+    if (m_offscreenDepthImage) {
+        vkDestroyImage(device, m_offscreenDepthImage, nullptr);
+        m_offscreenDepthImage = VK_NULL_HANDLE;
+    }
+    if (m_offscreenDepthMemory) {
+        vkFreeMemory(device, m_offscreenDepthMemory, nullptr);
+        m_offscreenDepthMemory = VK_NULL_HANDLE;
+    }
+}
+
+void Renderer::createOffscreenRenderPass() {
+    VkAttachmentDescription colorAttachment{};
+    colorAttachment.format = m_offscreenFormat;
+    colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    colorAttachment.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkAttachmentDescription depthAttachment{};
+    depthAttachment.format = m_SwapChain->findDepthFormat();
+    depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference colorAttachmentRef{};
+    colorAttachmentRef.attachment = 0;
+    colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference depthAttachmentRef{};
+    depthAttachmentRef.attachment = 1;
+    depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &colorAttachmentRef;
+    subpass.pDepthStencilAttachment = &depthAttachmentRef;
+
+    // Subpass dependency for layout transitions
+    VkSubpassDependency dependency{};
+    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass = 0;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcAccessMask = 0;
+    dependency.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency.dependencyFlags = 0;
+
+    std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
+
+    VkRenderPassCreateInfo renderPassInfo{};
+    renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+    renderPassInfo.pAttachments = attachments.data();
+    renderPassInfo.subpassCount = 1;
+    renderPassInfo.pSubpasses = &subpass;
+    renderPassInfo.dependencyCount = 1;
+    renderPassInfo.pDependencies = &dependency;
+
+    if (vkCreateRenderPass(deviceRef.device(), &renderPassInfo, nullptr, &m_offscreenRenderPass) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create offscreen render pass!");
+    }
+}
+
+void Renderer::createOffscreenFramebuffer() {
+    std::array<VkImageView, 2> attachments = {m_offscreenImageView, m_offscreenDepthView};
+
+    VkFramebufferCreateInfo framebufferInfo{};
+    framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    framebufferInfo.renderPass = m_offscreenRenderPass;
+    framebufferInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+    framebufferInfo.pAttachments = attachments.data();
+    framebufferInfo.width = m_offscreenExtent.width;
+    framebufferInfo.height = m_offscreenExtent.height;
+    framebufferInfo.layers = 1;
+
+    if (vkCreateFramebuffer(deviceRef.device(), &framebufferInfo, nullptr, &m_offscreenFramebuffer) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create offscreen framebuffer!");
+    }
+}
+
+void Renderer::createOffscreenDescriptorSet() {
+    auto device = deviceRef.device();
+
+    // Descriptor pool for one sampled image
+    VkDescriptorPoolSize poolSize{};
+    poolSize.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    poolSize.descriptorCount = 1;
+
+    VkDescriptorPoolCreateInfo poolInfo{};
+    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolInfo.poolSizeCount = 1;
+    poolInfo.pPoolSizes = &poolSize;
+    poolInfo.maxSets = 1;
+    if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_offscreenDescriptorPool) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create descriptor pool for offscreen image!");
+    }
+
+    // Descriptor set layout for one combined sampler
+    VkDescriptorSetLayoutBinding samplerLayoutBinding{};
+    samplerLayoutBinding.binding = 0;
+    samplerLayoutBinding.descriptorCount = 1;
+    samplerLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    samplerLayoutBinding.pImmutableSamplers = nullptr;
+    samplerLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    VkDescriptorSetLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutInfo.bindingCount = 1;
+    layoutInfo.pBindings = &samplerLayoutBinding;
+    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_offscreenDescriptorSetLayout) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create descriptor set layout for offscreen image!");
+    }
+
+    // Allocate descriptor set
+    VkDescriptorSetAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocInfo.descriptorPool = m_offscreenDescriptorPool;
+    allocInfo.descriptorSetCount = 1;
+    allocInfo.pSetLayouts = &m_offscreenDescriptorSetLayout;
+    if (vkAllocateDescriptorSets(device, &allocInfo, &m_offscreenImGuiDescriptorSet) != VK_SUCCESS) {
+        throw std::runtime_error("failed to allocate descriptor set for offscreen image!");
+    }
+
+    // Update descriptor set for the offscreen image
+    VkDescriptorImageInfo imageInfo{};
+    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageInfo.imageView = m_offscreenImageView;
+    imageInfo.sampler = m_offscreenSampler;
+
+    VkWriteDescriptorSet descriptorWrite{};
+    descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    descriptorWrite.dstSet = m_offscreenImGuiDescriptorSet;
+    descriptorWrite.dstBinding = 0;
+    descriptorWrite.dstArrayElement = 0;
+    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    descriptorWrite.descriptorCount = 1;
+    descriptorWrite.pImageInfo = &imageInfo;
+
+    vkUpdateDescriptorSets(device, 1, &descriptorWrite, 0, nullptr);
+}
+
+void Renderer::beginOffscreenRenderPass(VkCommandBuffer commandBuffer) {
+    if (m_offscreenCurrentLayout != VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
+        transitionImageLayout(m_offscreenImage, m_offscreenCurrentLayout, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+        m_offscreenCurrentLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    }
+
+    VkRenderPassBeginInfo renderPassInfo{};
+    renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    renderPassInfo.renderPass = m_offscreenRenderPass;
+    renderPassInfo.framebuffer = m_offscreenFramebuffer;
+    renderPassInfo.renderArea.offset = {0, 0};
+    renderPassInfo.renderArea.extent = m_offscreenExtent;
+
+    std::array<VkClearValue, 2> clearValues{};
+    clearValues[0].color = {0.1f, 0.1f, 0.15f, 1.0f};
+    clearValues[1].depthStencil = {1.0f, 0};
+    renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
+    renderPassInfo.pClearValues = clearValues.data();
+
+    vkCmdBeginRenderPass(commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+    VkViewport viewport{};
+    viewport.x = 0.0f;
+    viewport.y = 0.0f;
+    viewport.width = static_cast<float>(m_offscreenExtent.width);
+    viewport.height = static_cast<float>(m_offscreenExtent.height);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    VkRect2D scissor{{0, 0}, m_offscreenExtent};
+    vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
+    vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
+}
+
+void Renderer::endOffscreenRenderPass(VkCommandBuffer commandBuffer) const {
+    vkCmdEndRenderPass(commandBuffer);
+}
+
+void Renderer::transitionOffscreenImageForImGui() {
+    if (m_offscreenCurrentLayout != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        transitionImageLayout(m_offscreenImage, m_offscreenCurrentLayout, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        m_offscreenCurrentLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+}
+
+void Renderer::transitionImageLayout(VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout) {
+    VkCommandBuffer commandBuffer = deviceRef.beginSingleTimeCommands();
+
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+
+    VkPipelineStageFlags sourceStage;
+    VkPipelineStageFlags destinationStage;
+
+    if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
+        barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else {
+        throw std::invalid_argument("Unsupported layout transition!");
+    }
+
+    vkCmdPipelineBarrier(
+        commandBuffer,
+        sourceStage, destinationStage,
+        0, 0, nullptr, 0, nullptr, 1, &barrier
+    );
+
+    deviceRef.endSingleTimeCommands(commandBuffer);
 }
 
 } // Namespace KaguEngine

--- a/KaguEngine/src/Renderer.ixx
+++ b/KaguEngine/src/Renderer.ixx
@@ -44,10 +44,15 @@ public:
     void beginSwapChainRenderPass(VkCommandBuffer commandBuffer) const;
     void endSwapChainRenderPass(VkCommandBuffer commandBuffer) const;
 
-    std::unique_ptr<SwapChain>& getSwapChain() { return m_SwapChain; }
+    // Off screen render pass
+    void beginOffscreenRenderPass(VkCommandBuffer commandBuffer);
+    void endOffscreenRenderPass(VkCommandBuffer commandBuffer) const;
+    void transitionOffscreenImageForImGui();
 
-    [[nodiscard]] bool isSwapChainRecreated() const { return m_isSwapChainRecreated; }
-    void setSwapChainRecreated() { m_isSwapChainRecreated = false; }
+    [[nodiscard]] VkDescriptorSet getOffscreenImGuiDescriptorSet() const { return m_offscreenImGuiDescriptorSet; }
+    [[nodiscard]] VkExtent2D getOffscreenExtent() const { return m_offscreenExtent; }
+
+    std::unique_ptr<SwapChain>& getSwapChain() { return m_SwapChain; }
 
 private:
     void createCommandBuffers();
@@ -62,7 +67,30 @@ private:
     uint32_t m_currentImageIndex;
     int m_currentFrameIndex{0};
     bool m_isFrameStarted{false};
-    bool m_isSwapChainRecreated{false};
+
+    // Off screen rendering
+    VkImage m_offscreenImage = VK_NULL_HANDLE;
+    VkDeviceMemory m_offscreenImageMemory = VK_NULL_HANDLE;
+    VkImageView m_offscreenImageView = VK_NULL_HANDLE;
+    VkFramebuffer m_offscreenFramebuffer = VK_NULL_HANDLE;
+    VkRenderPass m_offscreenRenderPass = VK_NULL_HANDLE;
+    VkSampler m_offscreenSampler = VK_NULL_HANDLE;
+    VkDescriptorSet m_offscreenImGuiDescriptorSet = VK_NULL_HANDLE;
+    VkDescriptorPool m_offscreenDescriptorPool = VK_NULL_HANDLE;
+    VkImageLayout m_offscreenCurrentLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VkDescriptorSetLayout m_offscreenDescriptorSetLayout = VK_NULL_HANDLE;
+    VkFormat m_offscreenFormat = VK_FORMAT_B8G8R8A8_SRGB;
+    VkExtent2D m_offscreenExtent{};
+    VkImage m_offscreenDepthImage = VK_NULL_HANDLE;
+    VkDeviceMemory m_offscreenDepthMemory = VK_NULL_HANDLE;
+    VkImageView m_offscreenDepthView = VK_NULL_HANDLE;
+
+    void createOffscreenResources();
+    void cleanupOffscreenResources();
+    void createOffscreenRenderPass();
+    void createOffscreenFramebuffer();
+    void createOffscreenDescriptorSet();
+    void transitionImageLayout(VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout);
 };
 
 } // Namespace KaguEngine

--- a/KaguEngine/src/Renderer.ixx
+++ b/KaguEngine/src/Renderer.ixx
@@ -68,10 +68,6 @@ private:
     int m_currentFrameIndex{0};
     bool m_isFrameStarted{false};
 
-    // Off screen rendering
-    VkImage m_offscreenImage = VK_NULL_HANDLE;
-    VkDeviceMemory m_offscreenImageMemory = VK_NULL_HANDLE;
-    VkImageView m_offscreenImageView = VK_NULL_HANDLE;
     VkFramebuffer m_offscreenFramebuffer = VK_NULL_HANDLE;
     VkRenderPass m_offscreenRenderPass = VK_NULL_HANDLE;
     VkSampler m_offscreenSampler = VK_NULL_HANDLE;
@@ -81,6 +77,17 @@ private:
     VkDescriptorSetLayout m_offscreenDescriptorSetLayout = VK_NULL_HANDLE;
     VkFormat m_offscreenFormat = VK_FORMAT_B8G8R8A8_SRGB;
     VkExtent2D m_offscreenExtent{};
+
+    // Multi sampled color image
+    VkImage m_offscreenImage = VK_NULL_HANDLE;
+    VkDeviceMemory m_offscreenImageMemory = VK_NULL_HANDLE;
+    VkImageView m_offscreenImageView = VK_NULL_HANDLE;
+    // Resolve image - Not multi sampled
+    VkImage m_offscreenResolveImage = VK_NULL_HANDLE;
+    VkDeviceMemory m_offscreenResolveMemory = VK_NULL_HANDLE;
+    VkImageView m_offscreenResolveImageView = VK_NULL_HANDLE;
+
+    // Depth attachment
     VkImage m_offscreenDepthImage = VK_NULL_HANDLE;
     VkDeviceMemory m_offscreenDepthMemory = VK_NULL_HANDLE;
     VkImageView m_offscreenDepthView = VK_NULL_HANDLE;

--- a/KaguEngine/src/SwapChain.ixx
+++ b/KaguEngine/src/SwapChain.ixx
@@ -75,9 +75,9 @@ private:
     std::vector<VkImageView> m_DepthImageViews;
     std::vector<VkImage> m_SwapChainImages;
     std::vector<VkImageView> m_SwapChainImageViews;
-    std::vector<VkImage> m_ColorImages;
-    std::vector<VkDeviceMemory> m_ColorImageMemories;
-    std::vector<VkImageView> m_ColorImageViews;
+    std::vector<VkImage> m_MultisampleColorImages;
+    std::vector<VkDeviceMemory> m_MultisampleColorImageMemories;
+    std::vector<VkImageView> m_MultisampleColorImageViews;
 
     Device &deviceRef;
     VkExtent2D m_WindowExtent;

--- a/KaguEngine/src/systems/PointLightSystem.cpp
+++ b/KaguEngine/src/systems/PointLightSystem.cpp
@@ -61,7 +61,7 @@ void PointLightSystem::createPipeline(const VkRenderPass renderPass) {
     PipelineConfigInfo pipelineConfig{};
     Pipeline::defaultPipelineConfigInfo(pipelineConfig);
     Pipeline::enableAlphaBlending(pipelineConfig);
-    Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
+    //Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
     pipelineConfig.attributeDescriptions.clear();
     pipelineConfig.bindingDescriptions.clear();
     pipelineConfig.renderPass = renderPass;

--- a/KaguEngine/src/systems/PointLightSystem.cpp
+++ b/KaguEngine/src/systems/PointLightSystem.cpp
@@ -61,7 +61,7 @@ void PointLightSystem::createPipeline(const VkRenderPass renderPass) {
     PipelineConfigInfo pipelineConfig{};
     Pipeline::defaultPipelineConfigInfo(pipelineConfig);
     Pipeline::enableAlphaBlending(pipelineConfig);
-    //Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
+    Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
     pipelineConfig.attributeDescriptions.clear();
     pipelineConfig.bindingDescriptions.clear();
     pipelineConfig.renderPass = renderPass;

--- a/KaguEngine/src/systems/RenderSystem.cpp
+++ b/KaguEngine/src/systems/RenderSystem.cpp
@@ -69,7 +69,7 @@ void RenderSystem::createPipeline(const VkRenderPass renderPass) {
 
     PipelineConfigInfo pipelineConfig{};
     Pipeline::defaultPipelineConfigInfo(pipelineConfig);
-    Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
+    //Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
     pipelineConfig.renderPass = renderPass;
     pipelineConfig.pipelineLayout = m_pipelineLayout;
     m_Pipeline = std::make_unique<Pipeline>(

--- a/KaguEngine/src/systems/RenderSystem.cpp
+++ b/KaguEngine/src/systems/RenderSystem.cpp
@@ -69,7 +69,8 @@ void RenderSystem::createPipeline(const VkRenderPass renderPass) {
 
     PipelineConfigInfo pipelineConfig{};
     Pipeline::defaultPipelineConfigInfo(pipelineConfig);
-    //Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
+    Pipeline::enableAlphaBlending(pipelineConfig);
+    Pipeline::enableMSAA(pipelineConfig, m_Device.getSampleCount());
     pipelineConfig.renderPass = renderPass;
     pipelineConfig.pipelineLayout = m_pipelineLayout;
     m_Pipeline = std::make_unique<Pipeline>(


### PR DESCRIPTION
With changes made to the ImGuiContext and a few changes with the swap chain, render passes and an offscreen rendering system to have the 3D scene viewport presented on an ImGui image, the application can look like this, while having a complete control of the windows positioning thanks to the ImGui docking branch.

TL;DR
The whole app is now a dockspace containing a viewport for the 3D scene + ImGui windows.

![image](https://github.com/user-attachments/assets/452ba856-1a8d-4720-9b27-b7594b0cfad1)